### PR TITLE
Add OpenAPI configuration and update Docker setup for Swagger integra…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,8 @@ jobs:
         run: |
           ssh -o StrictHostKeyChecking=no ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} << 'EOF'
             cd ~/deploy/${{ github.event.repository.name }}
+            echo "SWAGGER_SERVER_URL=${{ secrets.SWAGGER_SERVER_URL }}" > .env
+            docker compose down --remove-orphans
             docker compose build
             docker compose up -d --remove-orphans
             docker system prune -f

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - DB_USER=user
       - DB_PASSWORD=password
       - SERVER_PORT=0
+      - SWAGGER_SERVER_URL=${SWAGGER_SERVER_URL}
     networks:
       - shared_network
 networks:

--- a/src/main/java/com/gtu/route_management_service/OpenAPIConfig.java
+++ b/src/main/java/com/gtu/route_management_service/OpenAPIConfig.java
@@ -1,0 +1,18 @@
+package com.gtu.route_management_service;
+
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.servers.Server;
+
+
+@Configuration
+@OpenAPIDefinition(
+    info = @Info(title = "Mi API", version = "1.0"),
+    servers = {
+        @Server(url = "${SWAGGER_SERVER_URL:http://localhost/api/route-management}", description = "Server URL")
+    }
+)
+public class OpenAPIConfig {
+}

--- a/src/main/java/com/gtu/route_management_service/presentation/rest/NeighborhoodController.java
+++ b/src/main/java/com/gtu/route_management_service/presentation/rest/NeighborhoodController.java
@@ -53,12 +53,14 @@ public class NeighborhoodController {
 
 
     @DeleteMapping("/{id}")
+    @Operation(summary = "Delete a neighborhood", description = "Remove a neighborhood from the system by its unique identifier.")
     public ResponseEntity<ResponseDTO<Long>> deleteNeighborhood(@PathVariable Long id) {
         neighborhoodUseCase.deleteNeighborhood(id);
         return ResponseEntity.status(200).body(new ResponseDTO<>("Neighborhood deleted successfully", id, 200));
     }
 
     @PutMapping
+    @Operation(summary = "Update a neighborhood", description = "Modify an existing neighborhood in the system.")
     public ResponseEntity<ResponseDTO<NeighborhoodDTO>> updateNeighborhood(@RequestBody NeighborhoodDTO neighborhoodDTO) {
         NeighborhoodDTO updatedNeighborhood = neighborhoodUseCase.updateNeighborhood(neighborhoodDTO);
         return ResponseEntity.status(200).body(new ResponseDTO<>("Neighborhood updated successfully", updatedNeighborhood, 200));

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,3 +11,6 @@ eureka.instance.instance-id=${spring.application.name}:${spring.application.inst
 eureka.client.service-url.defaultZone=http://${EUREKA_SERVER_HOST:discovery-server}:${EUREKA_SERVER_PORT:8761}/eureka/
 eureka.client.register-with-eureka=true
 eureka.client.fetch-registry=true
+
+springdoc.api-docs.path=/v3/api-docs
+springdoc.swagger-ui.enabled=false


### PR DESCRIPTION
This pull request includes several changes to integrate Swagger for API documentation and improve the deployment process. The most important changes include adding Swagger configuration, updating environment variables, and enhancing API endpoint documentation.

### Swagger Integration:

* [`src/main/java/com/gtu/route_management_service/OpenAPIConfig.java`](diffhunk://#diff-768891d00fddf08186e88889f863a3327e41544cf6bf0fc537c2e011e75f6ca7R1-R18): Added Swagger configuration to define API information and server URL using `OpenAPIDefinition` and `Server` annotations.
* [`src/main/resources/application.properties`](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136R14-R16): Configured the path for API documentation and disabled the Swagger UI.

### Deployment Process:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R41-R42): Updated the deployment script to set the `SWAGGER_SERVER_URL` environment variable and ensure Docker containers are properly managed.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R15): Added `SWAGGER_SERVER_URL` to the environment variables for the Docker services.

### API Endpoint Documentation:

* [`src/main/java/com/gtu/route_management_service/presentation/rest/NeighborhoodController.java`](diffhunk://#diff-bab095548e0a13dae82756c926c450412f2ea7cee23c5f564f6686c920be6985R56-R63): Added `@Operation` annotations to document the `deleteNeighborhood` and `updateNeighborhood` endpoints.