### PR TITLE
Add CORS support to Neighborhood, Route, and Stop controllers

### DIFF
--- a/src/main/java/com/gtu/route_management_service/presentation/rest/NeighborhoodController.java
+++ b/src/main/java/com/gtu/route_management_service/presentation/rest/NeighborhoodController.java
@@ -15,6 +15,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/neighborhoods")
 @Tag(name = "Neighborhoods", description = "Endpoints for managing neighborhoods")
+@CrossOrigin(origins = "*")
 public class NeighborhoodController {
 
     private final NeighborhoodUseCase neighborhoodUseCase;

--- a/src/main/java/com/gtu/route_management_service/presentation/rest/RouteController.java
+++ b/src/main/java/com/gtu/route_management_service/presentation/rest/RouteController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/routes")
 @Tag    (name = "Routes", description = "Endpoints for managing routes")
+@CrossOrigin(origins = "*")
 public class RouteController {
     private final RouteUseCase routeUseCase;
 

--- a/src/main/java/com/gtu/route_management_service/presentation/rest/StopController.java
+++ b/src/main/java/com/gtu/route_management_service/presentation/rest/StopController.java
@@ -15,6 +15,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/stops")
 @Tag(name = "Stops", description = "Endpoints for managing stops")
+@CrossOrigin(origins = "*")
 public class StopController {
     private final StopUseCase stopUseCase;
 


### PR DESCRIPTION
This pull request includes changes to add Cross-Origin Resource Sharing (CORS) support to multiple controllers in the `route_management_service` module. The most important changes involve adding the `@CrossOrigin` annotation to allow requests from any origin.