### PR TITLE
Add CI workflow for testing with Maven and JDK 17

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,32 @@ on:
       - develop
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Cache Maven packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Run tests
+        run: mvn test
+
   deploy:
+    needs: test
     runs-on: ubuntu-latest
     environment: dev
     steps:


### PR DESCRIPTION
This pull request includes the addition of a new job to the GitHub Actions workflow in the `.github/workflows/deploy.yml` file. The changes primarily focus on setting up a testing environment before deployment.

Key changes include:

* **Testing Job Addition:**
  - Added a new job named `test` that runs on `ubuntu-latest`.
  - Steps within the `test` job include checking out the code, setting up JDK 17 using `actions/setup-java@v3`, caching Maven packages, and running tests using `mvn test`.

* **Deployment Job Update:**
  - Modified the `deploy` job to depend on the completion of the `test` job by adding `needs: test`.