### PR TITLE
Test/stop service

### DIFF
--- a/src/main/java/com/gtu/route_management_service/application/dto/StopDTO.java
+++ b/src/main/java/com/gtu/route_management_service/application/dto/StopDTO.java
@@ -1,6 +1,7 @@
 package com.gtu.route_management_service.application.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -15,6 +16,7 @@ public class StopDTO {
     private Long id;
     
     @Schema(description = "Name of the stop", example = "Main Street")
+    @NotEmpty(message = "Stop name cannot be empty")
     private String name;
 
     @Schema(description = "Description of the stop", example = "This stop is located at Main Street and 1st Avenue")

--- a/src/main/java/com/gtu/route_management_service/application/service/StopServiceImpl.java
+++ b/src/main/java/com/gtu/route_management_service/application/service/StopServiceImpl.java
@@ -23,6 +23,9 @@ public class StopServiceImpl implements StopService {
 
     @Override
     public Stop createStop(Stop stop) {
+        if (stop.getName() == null || stop.getName().isEmpty()) {
+            throw new IllegalArgumentException("Stop name cannot be empty");
+        }
         if (!neighborhoodRepository.existsById(stop.getNeighborhoodId())) {
             throw new IllegalArgumentException("Neighborhood does not exist");
         }

--- a/src/test/java/com/gtu/route_management_service/application/service/StopServiceImplTest.java
+++ b/src/test/java/com/gtu/route_management_service/application/service/StopServiceImplTest.java
@@ -1,0 +1,201 @@
+package com.gtu.route_management_service.application.service;
+
+import com.gtu.route_management_service.domain.model.Stop;
+import com.gtu.route_management_service.domain.repository.NeighborhoodRepository;
+import com.gtu.route_management_service.domain.repository.StopRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class StopServiceImplTest {
+
+    @Mock
+    private StopRepository stopRepository;
+
+    @Mock
+    private NeighborhoodRepository neighborhoodRepository;
+
+    @InjectMocks
+    private StopServiceImpl stopService;
+
+    private Stop stop;
+
+    @BeforeEach
+    void setUp() {
+        stop = new Stop(1L, "Main Stop", "Central stop", 1L, 40.7128, -74.0060);
+    }
+
+    @Test
+    void createStop_Success() {
+        Stop inputStop = new Stop("Main Stop", "Central stop", 1L, 40.7128, -74.0060);
+        when(neighborhoodRepository.existsById(1L)).thenReturn(true);
+        when(stopRepository.save(any(Stop.class))).thenReturn(stop);
+        Stop createdStop = stopService.createStop(inputStop);
+
+        assertNotNull(createdStop);
+        assertEquals("Main Stop", createdStop.getName());
+        assertEquals("Central stop", createdStop.getDescription());
+        assertEquals(1L, createdStop.getNeighborhoodId());
+        assertEquals(40.7128, createdStop.getLatitude());
+        assertEquals(-74.0060, createdStop.getLongitude());
+        verify(neighborhoodRepository, times(1)).existsById(1L);
+        verify(stopRepository, times(1)).save(inputStop);
+    }
+
+    @Test
+    void createStop_EmptyName_ThrowsException() {
+        Stop inputStop = new Stop("", "Central stop", 1L, 40.7128, -74.0060);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            stopService.createStop(inputStop);
+        });
+
+        assertEquals("Stop name cannot be empty", exception.getMessage());
+        verify(neighborhoodRepository, never()).existsById(anyLong());
+        verify(stopRepository, never()).save(any(Stop.class));
+    }
+
+    @Test
+    void createStop_NeighborhoodNotFound_ThrowsException() {
+        Stop inputStop = new Stop("Main Stop", "Central stop", 1L, 40.7128, -74.0060);
+        when(neighborhoodRepository.existsById(1L)).thenReturn(false);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            stopService.createStop(inputStop);
+        });
+
+        assertEquals("Neighborhood does not exist", exception.getMessage());
+        verify(neighborhoodRepository, times(1)).existsById(1L);
+        verify(stopRepository, never()).save(any(Stop.class));
+    }
+
+    @Test
+    void getAllStops_Success() {
+        List<Stop> stops = Arrays.asList(stop);
+        when(stopRepository.findAll()).thenReturn(stops);
+        List<Stop> result = stopService.getAllStops();
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals("Main Stop", result.get(0).getName());
+        verify(stopRepository, times(1)).findAll();
+    }
+
+    @Test
+    void getAllStops_EmptyList() {
+        when(stopRepository.findAll()).thenReturn(Collections.emptyList());
+        List<Stop> result = stopService.getAllStops();
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+        verify(stopRepository, times(1)).findAll();
+    }
+
+    @Test
+    void getStopById_Success() {
+        when(stopRepository.findById(1L)).thenReturn(Optional.of(stop));
+        Optional<Stop> result = stopService.getStopById(1L);
+
+        assertTrue(result.isPresent());
+        assertEquals("Main Stop", result.get().getName());
+        verify(stopRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    void getStopById_NotFound() {
+        when(stopRepository.findById(1L)).thenReturn(Optional.empty());
+        Optional<Stop> result = stopService.getStopById(1L);
+
+        assertFalse(result.isPresent());
+        verify(stopRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    void deleteStop_Success() {
+        doNothing().when(stopRepository).deleteById(1L);
+        stopService.deleteStop(1L);
+
+        verify(stopRepository, times(1)).deleteById(1L);
+    }
+
+    @Test
+    void updateStop_Success() {
+        Stop updatedStop = new Stop(1L, "Updated Stop", "Updated description", 1L, 41.7128, -75.0060);
+        when(stopRepository.existsById(1L)).thenReturn(true);
+        when(neighborhoodRepository.existsById(1L)).thenReturn(true);
+        when(stopRepository.update(any(Stop.class))).thenReturn(updatedStop);
+        Stop result = stopService.updateStop(stop);
+
+        assertNotNull(result);
+        assertEquals("Updated Stop", result.getName());
+        assertEquals("Updated description", result.getDescription());
+        assertEquals(1L, result.getNeighborhoodId());
+        assertEquals(41.7128, result.getLatitude());
+        assertEquals(-75.0060, result.getLongitude());
+        verify(stopRepository, times(1)).existsById(1L);
+        verify(neighborhoodRepository, times(1)).existsById(1L);
+        verify(stopRepository, times(1)).update(stop);
+    }
+
+    @Test
+    void updateStop_StopNotFound_ThrowsException() {
+        when(stopRepository.existsById(1L)).thenReturn(false);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            stopService.updateStop(stop);
+        });
+
+        assertEquals("Stop does not exist", exception.getMessage());
+        verify(stopRepository, times(1)).existsById(1L);
+        verify(neighborhoodRepository, never()).existsById(anyLong());
+        verify(stopRepository, never()).update(any(Stop.class));
+    }
+
+    @Test
+    void updateStop_NeighborhoodNotFound_ThrowsException() {
+        when(stopRepository.existsById(1L)).thenReturn(true);
+        when(neighborhoodRepository.existsById(1L)).thenReturn(false);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            stopService.updateStop(stop);
+        });
+
+        assertEquals("Neighborhood does not exist", exception.getMessage());
+        verify(stopRepository, times(1)).existsById(1L);
+        verify(neighborhoodRepository, times(1)).existsById(1L);
+        verify(stopRepository, never()).update(any(Stop.class));
+    }
+
+    @Test
+    void searchByName_Success() {
+        List<Stop> stops = Arrays.asList(stop);
+        when(stopRepository.searchByName("Main")).thenReturn(stops);
+        List<Stop> result = stopService.searchByName("Main");
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals("Main Stop", result.get(0).getName());
+        verify(stopRepository, times(1)).searchByName("Main");
+    }
+
+    @Test
+    void searchByName_EmptyList() {
+        when(stopRepository.searchByName("Main")).thenReturn(Collections.emptyList());
+        List<Stop> result = stopService.searchByName("Main");
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+        verify(stopRepository, times(1)).searchByName("Main");
+    }
+}

--- a/src/test/java/com/gtu/route_management_service/application/usecase/StopUseCaseTest.java
+++ b/src/test/java/com/gtu/route_management_service/application/usecase/StopUseCaseTest.java
@@ -1,0 +1,176 @@
+package com.gtu.route_management_service.application.usecase;
+
+import com.gtu.route_management_service.application.dto.StopDTO;
+import com.gtu.route_management_service.domain.model.Stop;
+import com.gtu.route_management_service.domain.service.StopService;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class StopUseCaseTest {
+
+    @Mock
+    private StopService stopService;
+
+    @InjectMocks
+    private StopUseCase stopUseCase;
+
+    private Stop stop;
+    private StopDTO stopDTO;
+
+    @BeforeEach
+    void setUp() {
+        stop = new Stop(1L, "Main Stop", "Central stop", 1L, 40.7128, -74.0060);
+        stopDTO = new StopDTO(1L, "Main Stop", "Central stop", 1L, 40.7128, -74.0060);
+    }
+
+    @Test
+    void createStop_Success() {
+        when(stopService.createStop(any(Stop.class))).thenReturn(stop);
+        StopDTO result = stopUseCase.createStop(stopDTO);
+
+        assertNotNull(result);
+        assertEquals("Main Stop", result.getName());
+        assertEquals("Central stop", result.getDescription());
+        assertEquals(1L, result.getNeighborhoodId());
+        assertEquals(40.7128, result.getLatitude());
+        assertEquals(-74.0060, result.getLongitude());
+        verify(stopService, times(1)).createStop(any(Stop.class));
+    }
+
+    @Test
+    void createStop_NullDTO_ReturnsNull() {
+        StopDTO result = stopUseCase.createStop(null);
+
+        assertNull(result);
+        verify(stopService, never()).createStop(any(Stop.class));
+    }
+
+    @Test
+    void getAllStops_Success() {
+        List<Stop> stops = Arrays.asList(stop);
+        when(stopService.getAllStops()).thenReturn(stops);
+        List<StopDTO> result = stopUseCase.getAllStops();
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals("Main Stop", result.get(0).getName());
+        verify(stopService, times(1)).getAllStops();
+    }
+
+    @Test
+    void getAllStops_EmptyList() {
+        when(stopService.getAllStops()).thenReturn(Collections.emptyList());
+        List<StopDTO> result = stopUseCase.getAllStops();
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+        verify(stopService, times(1)).getAllStops();
+    }
+
+    @Test
+    void getAllStops_NullList_ReturnsEmptyList() {
+        when(stopService.getAllStops()).thenReturn(null);
+        List<StopDTO> result = stopUseCase.getAllStops();
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+        verify(stopService, times(1)).getAllStops();
+    }
+
+    @Test
+    void getStopById_Success() {
+        when(stopService.getStopById(1L)).thenReturn(Optional.of(stop));
+        StopDTO result = stopUseCase.getStopById(1L);
+
+        assertNotNull(result);
+        assertEquals("Main Stop", result.getName());
+        verify(stopService, times(1)).getStopById(1L);
+    }
+
+    @Test
+    void getStopById_NotFound() {
+        when(stopService.getStopById(1L)).thenReturn(Optional.empty());
+        StopDTO result = stopUseCase.getStopById(1L);
+
+        assertNull(result);
+        verify(stopService, times(1)).getStopById(1L);
+    }
+
+    @Test
+    void deleteStop_Success() {
+        doNothing().when(stopService).deleteStop(1L);
+        stopUseCase.deleteStop(1L);
+
+        verify(stopService, times(1)).deleteStop(1L);
+    }
+
+    @Test
+    void updateStop_Success() {
+        Stop updatedStop = new Stop(1L, "Updated Stop", "Updated description", 1L, 41.7128, -75.0060);
+        when(stopService.updateStop(any(Stop.class))).thenReturn(updatedStop);
+        StopDTO result = stopUseCase.updateStop(stopDTO);
+
+        assertNotNull(result);
+        assertEquals("Updated Stop", result.getName());
+        assertEquals("Updated description", result.getDescription());
+        assertEquals(1L, result.getNeighborhoodId());
+        assertEquals(41.7128, result.getLatitude());
+        assertEquals(-75.0060, result.getLongitude());
+        verify(stopService, times(1)).updateStop(any(Stop.class));
+    }
+
+    @Test
+    void updateStop_NullDTO_ReturnsNull() {
+        StopDTO result = stopUseCase.updateStop(null);
+
+        assertNull(result);
+        verify(stopService, never()).updateStop(any(Stop.class));
+    }
+
+    @Test
+    void searchByName_Success() {
+        List<Stop> stops = Arrays.asList(stop);
+        when(stopService.searchByName("Main")).thenReturn(stops);
+        List<StopDTO> result = stopUseCase.searchByName("Main");
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals("Main Stop", result.get(0).getName());
+        verify(stopService, times(1)).searchByName("Main");
+    }
+
+    @Test
+    void searchByName_EmptyList() {
+        when(stopService.searchByName("Main")).thenReturn(Collections.emptyList());
+        List<StopDTO> result = stopUseCase.searchByName("Main");
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+        verify(stopService, times(1)).searchByName("Main");
+    }
+
+    @Test
+    void searchByName_NullList_ReturnsEmptyList() {
+        when(stopService.searchByName("Main")).thenReturn(null);
+        List<StopDTO> result = stopUseCase.searchByName("Main");
+        
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+        verify(stopService, times(1)).searchByName("Main");
+    }
+}

--- a/src/test/java/com/gtu/route_management_service/presentation/rest/StopControllerTest.java
+++ b/src/test/java/com/gtu/route_management_service/presentation/rest/StopControllerTest.java
@@ -1,0 +1,229 @@
+package com.gtu.route_management_service.presentation.rest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gtu.route_management_service.application.dto.StopDTO;
+import com.gtu.route_management_service.presentation.exception.GlobalExceptionHandler;
+import com.gtu.route_management_service.application.usecase.StopUseCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class StopControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private StopUseCase stopUseCase;
+
+    @InjectMocks
+    private StopController stopController;
+
+    private ObjectMapper objectMapper;
+
+    private StopDTO stopDTO;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        stopDTO = new StopDTO(1L, "Main Stop", "Central stop", 1L, 40.7128, -74.0060);
+
+        mockMvc = MockMvcBuilders.standaloneSetup(stopController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void createStop_Success() throws Exception {
+        StopDTO inputDTO = new StopDTO(null, "New Stop", "New description", 1L, 40.7128, -74.0060);
+        StopDTO createdDTO = new StopDTO(2L, "New Stop", "New description", 1L, 40.7128, -74.0060);
+        when(stopUseCase.createStop(any(StopDTO.class))).thenReturn(createdDTO);
+
+        ResultActions result = mockMvc.perform(post("/stops")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(inputDTO)));
+
+        result.andExpect(status().isCreated())
+                .andExpect(jsonPath("$.message", is("Stop created successfully")))
+                .andExpect(jsonPath("$.status", is(201)))
+                .andExpect(jsonPath("$.data.id", is(2)))
+                .andExpect(jsonPath("$.data.name", is("New Stop")));
+
+        verify(stopUseCase, times(1)).createStop(any(StopDTO.class));
+    }
+
+    @Test
+    void createStop_NeighborhoodNotFound_ThrowsException() throws Exception {
+        StopDTO inputDTO = new StopDTO(null, "New Stop", "New description", 1L, 40.7128, -74.0060);
+        when(stopUseCase.createStop(any(StopDTO.class)))
+                .thenThrow(new IllegalArgumentException("Neighborhood does not exist"));
+
+        ResultActions result = mockMvc.perform(post("/stops")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(inputDTO)));
+
+        result.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status", is(400)))
+                .andExpect(jsonPath("$.error", is("Invalid Argument")))
+                .andExpect(jsonPath("$.message", is("Neighborhood does not exist")))
+                .andExpect(jsonPath("$.path", is("/stops")));
+
+        verify(stopUseCase, times(1)).createStop(any(StopDTO.class));
+    }
+
+    @Test
+    void getAllStops_Success() throws Exception {
+        List<StopDTO> stops = Arrays.asList(stopDTO);
+        when(stopUseCase.getAllStops()).thenReturn(stops);
+
+        ResultActions result = mockMvc.perform(get("/stops")
+                .contentType(MediaType.APPLICATION_JSON));
+
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.message", is("Stops retrieved successfully")))
+                .andExpect(jsonPath("$.status", is(200)))
+                .andExpect(jsonPath("$.data", hasSize(1)))
+                .andExpect(jsonPath("$.data[0].id", is(1)))
+                .andExpect(jsonPath("$.data[0].name", is("Main Stop")));
+
+        verify(stopUseCase, times(1)).getAllStops();
+        verify(stopUseCase, never()).searchByName(anyString());
+    }
+
+    @Test
+    void getAllStops_WithSearch_Success() throws Exception {
+        List<StopDTO> stops = Arrays.asList(stopDTO);
+        when(stopUseCase.searchByName("Main")).thenReturn(stops);
+
+        ResultActions result = mockMvc.perform(get("/stops")
+                .param("search", "Main")
+                .contentType(MediaType.APPLICATION_JSON));
+
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.message", is("Stops retrieved successfully")))
+                .andExpect(jsonPath("$.status", is(200)))
+                .andExpect(jsonPath("$.data", hasSize(1)))
+                .andExpect(jsonPath("$.data[0].id", is(1)))
+                .andExpect(jsonPath("$.data[0].name", is("Main Stop")));
+
+        verify(stopUseCase, times(1)).searchByName("Main");
+        verify(stopUseCase, never()).getAllStops();
+    }
+
+    @Test
+    void getAllStops_EmptyList() throws Exception {
+        when(stopUseCase.getAllStops()).thenReturn(Collections.emptyList());
+
+        ResultActions result = mockMvc.perform(get("/stops")
+                .contentType(MediaType.APPLICATION_JSON));
+
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.message", is("Stops retrieved successfully")))
+                .andExpect(jsonPath("$.status", is(200)))
+                .andExpect(jsonPath("$.data", hasSize(0)));
+
+        verify(stopUseCase, times(1)).getAllStops();
+        verify(stopUseCase, never()).searchByName(anyString());
+    }
+
+    @Test
+    void getStopById_Success() throws Exception {
+        when(stopUseCase.getStopById(1L)).thenReturn(stopDTO);
+
+        ResultActions result = mockMvc.perform(get("/stops/1")
+                .contentType(MediaType.APPLICATION_JSON));
+
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.message", is("Stop retrieved successfully")))
+                .andExpect(jsonPath("$.status", is(200)))
+                .andExpect(jsonPath("$.data.id", is(1)))
+                .andExpect(jsonPath("$.data.name", is("Main Stop")));
+
+        verify(stopUseCase, times(1)).getStopById(1L);
+    }
+
+    @Test
+    void getStopById_NotFound() throws Exception {
+        when(stopUseCase.getStopById(1L)).thenReturn(null);
+
+        ResultActions result = mockMvc.perform(get("/stops/1")
+                .contentType(MediaType.APPLICATION_JSON));
+
+        result.andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message", is("Stop not found")))
+                .andExpect(jsonPath("$.status", is(404)))
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+        verify(stopUseCase, times(1)).getStopById(1L);
+    }
+
+    @Test
+    void deleteStop_Success() throws Exception {
+        doNothing().when(stopUseCase).deleteStop(1L);
+
+        ResultActions result = mockMvc.perform(delete("/stops/1")
+                .contentType(MediaType.APPLICATION_JSON));
+
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.message", is("Stop deleted successfully")))
+                .andExpect(jsonPath("$.status", is(200)))
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+        verify(stopUseCase, times(1)).deleteStop(1L);
+    }
+
+    @Test
+    void updateStop_Success() throws Exception {
+        StopDTO inputDTO = new StopDTO(1L, "Updated Stop", "Updated description", 1L, 41.7128, -75.0060);
+        StopDTO updatedDTO = new StopDTO(1L, "Updated Stop", "Updated description", 1L, 41.7128, -75.0060);
+        when(stopUseCase.updateStop(any(StopDTO.class))).thenReturn(updatedDTO);
+
+        ResultActions result = mockMvc.perform(put("/stops")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(inputDTO)));
+
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.message", is("Stop updated successfully")))
+                .andExpect(jsonPath("$.status", is(200)))
+                .andExpect(jsonPath("$.data.id", is(1)))
+                .andExpect(jsonPath("$.data.name", is("Updated Stop")));
+
+        verify(stopUseCase, times(1)).updateStop(any(StopDTO.class));
+    }
+
+    @Test
+    void updateStop_StopNotFound_ThrowsException() throws Exception {
+        StopDTO inputDTO = new StopDTO(1L, "Updated Stop", "Updated description", 1L, 41.7128, -75.0060);
+        when(stopUseCase.updateStop(any(StopDTO.class)))
+                .thenThrow(new IllegalArgumentException("Stop does not exist"));
+
+        ResultActions result = mockMvc.perform(put("/stops")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(inputDTO)));
+
+        result.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status", is(400)))
+                .andExpect(jsonPath("$.error", is("Invalid Argument")))
+                .andExpect(jsonPath("$.message", is("Stop does not exist")))
+                .andExpect(jsonPath("$.path", is("/stops")));
+
+        verify(stopUseCase, times(1)).updateStop(any(StopDTO.class));
+    }
+}


### PR DESCRIPTION
This pull request includes several changes to the `route_management_service` to improve validation, service implementation, and testing. The key changes involve adding validation to the `StopDTO` class, updating the `StopServiceImpl` class to handle validation, and adding extensive unit tests for the service, use case, and controller layers.

### Validation and Service Implementation Enhancements:

* [`src/main/java/com/gtu/route_management_service/application/dto/StopDTO.java`](diffhunk://#diff-a02c7fd869af35113f8dc2d783ebfaaef09318f38053b49a64a8d9ef6e8afcafR4): Added `@NotEmpty` annotation to the `name` field to ensure stop names are not empty. 
* [`src/main/java/com/gtu/route_management_service/application/service/StopServiceImpl.java`](diffhunk://#diff-b49ff7c46f3e83c0029487faf04458b9c2e357de1da38efc0bc1c3d15c082c76R26-R28): Added validation to check if the stop name is null or empty and throw an `IllegalArgumentException` if it is.

### Unit Tests:

* [`src/test/java/com/gtu/route_management_service/application/service/StopServiceImplTest.java`](diffhunk://#diff-406c17b27a00922b0a39d153bf1da6ae5eea5fefbd2bc55dbb2c3d01dedb44e8R1-R201): Added comprehensive unit tests for the `StopServiceImpl` class, covering scenarios like creating stops, handling empty names, neighborhood existence checks, and CRUD operations.
* [`src/test/java/com/gtu/route_management_service/application/usecase/StopUseCaseTest.java`](diffhunk://#diff-00d606dfa22225ed4b0eb70cf1ee9f2e12e703730c83b4a964cefb4333f94474R1-R176): Added unit tests for the `StopUseCase` class to validate the interaction between the use case and service layers.
* [`src/test/java/com/gtu/route_management_service/presentation/rest/StopControllerTest.java`](diffhunk://#diff-b39a464d708507b5d2690ce6f406fb7b15eccc20ac9842d76231819609f2dcdeR1-R229): Added unit tests for the `StopController` class to ensure proper handling of HTTP requests and responses, including validation errors and successful CRUD operations.