### PR TITLE
Add unit tests for Neighborhood, Route, and Stop repositories and map…

### DIFF
--- a/src/test/java/com/gtu/route_management_service/infrastructure/persistence/NeighborhoodRepositoryImplTest.java
+++ b/src/test/java/com/gtu/route_management_service/infrastructure/persistence/NeighborhoodRepositoryImplTest.java
@@ -1,0 +1,75 @@
+package com.gtu.route_management_service.infrastructure.persistence;
+
+import com.gtu.route_management_service.domain.model.Neighborhood;
+import com.gtu.route_management_service.infrastructure.persistence.entities.NeighborhoodEntity;
+import com.gtu.route_management_service.infrastructure.persistence.mappers.NeighborhoodMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class NeighborhoodRepositoryImplTest {
+
+    @Mock
+    private JpaNeighborhoodRepository jpaRepo;
+
+    @InjectMocks
+    private NeighborhoodRepositoryImpl repository;
+
+    private final Neighborhood neighborhood = new Neighborhood(1L, "Centro");
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void save_ShouldReturnSavedNeighborhood() {
+        NeighborhoodEntity entity = NeighborhoodMapper.toEntity(neighborhood);
+        when(jpaRepo.save(any())).thenReturn(entity);
+
+        Neighborhood result = repository.save(neighborhood);
+
+        assertEquals(neighborhood.getId(), result.getId());
+    }
+
+    @Test
+    void findAll_ShouldReturnListOfNeighborhoods() {
+        when(jpaRepo.findAll()).thenReturn(List.of(NeighborhoodMapper.toEntity(neighborhood)));
+
+        List<Neighborhood> result = repository.findAll();
+
+        assertFalse(result.isEmpty());
+    }
+
+    @Test
+    void findById_ShouldReturnNeighborhood() {
+        when(jpaRepo.findById(1L)).thenReturn(Optional.of(NeighborhoodMapper.toEntity(neighborhood)));
+
+        Optional<Neighborhood> result = repository.findById(1L);
+
+        assertTrue(result.isPresent());
+        assertEquals(1L, result.get().getId());
+    }
+
+    @Test
+    void existsById_ShouldReturnTrue() {
+        when(jpaRepo.existsById(1L)).thenReturn(true);
+
+        assertTrue(repository.existsById(1L));
+    }
+
+    @Test
+    void deleteById_ShouldCallDelete() {
+        doNothing().when(jpaRepo).deleteById(1L);
+        repository.deleteById(1L);
+        verify(jpaRepo, times(1)).deleteById(1L);
+    }
+}

--- a/src/test/java/com/gtu/route_management_service/infrastructure/persistence/RouteRepositoryImplTest.java
+++ b/src/test/java/com/gtu/route_management_service/infrastructure/persistence/RouteRepositoryImplTest.java
@@ -1,0 +1,81 @@
+package com.gtu.route_management_service.infrastructure.persistence;
+
+import com.gtu.route_management_service.domain.model.Route;
+import com.gtu.route_management_service.infrastructure.persistence.entities.RouteEntity;
+import com.gtu.route_management_service.infrastructure.persistence.mappers.RouteEntityMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class RouteRepositoryImplTest {
+
+    @Mock
+    private JpaRouteRepository jpaRepo;
+
+    @InjectMocks
+    private RouteRepositoryImpl repository;
+
+    private final Route route = new Route(1L, "Ruta A", null, null, null, List.of(1L, 2L), List.of(10L, 20L));
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void save_ShouldReturnSavedRoute() {
+        RouteEntity entity = RouteEntityMapper.toEntity(route, List.of(), List.of());
+        when(jpaRepo.save(any())).thenReturn(entity);
+
+        Route result = repository.save(route);
+
+        assertEquals(route.getId(), result.getId());
+    }
+
+    @Test
+    void findAll_ShouldReturnListOfRoutes() {
+        when(jpaRepo.findAll()).thenReturn(List.of(RouteEntityMapper.toEntity(route, List.of(), List.of())));
+
+        List<Route> result = repository.findAll();
+
+        assertFalse(result.isEmpty());
+    }
+
+    @Test
+    void findByName_ShouldReturnRoute() {
+        when(jpaRepo.findByEntityName("Ruta A"))
+                .thenReturn(Optional.of(RouteEntityMapper.toEntity(route, List.of(), List.of())));
+
+        Optional<Route> result = repository.findByName("Ruta A");
+
+        assertTrue(result.isPresent());
+        assertEquals("Ruta A", result.get().getName());
+    }
+
+    @Test
+    void existsById_ShouldReturnRoute() {
+        when(jpaRepo.findByIdEntity(1L))
+                .thenReturn(Optional.of(RouteEntityMapper.toEntity(route, List.of(), List.of())));
+
+        Optional<Route> result = repository.existsById(1L);
+
+        assertTrue(result.isPresent());
+    }
+
+    @Test
+    void deleteById_ShouldCallDelete() {
+        doNothing().when(jpaRepo).deleteById(1L);
+
+        repository.deleteById(1L);
+
+        verify(jpaRepo, times(1)).deleteById(1L);
+    }
+}

--- a/src/test/java/com/gtu/route_management_service/infrastructure/persistence/StopRepositoryImplTest.java
+++ b/src/test/java/com/gtu/route_management_service/infrastructure/persistence/StopRepositoryImplTest.java
@@ -1,0 +1,75 @@
+package com.gtu.route_management_service.infrastructure.persistence;
+
+import com.gtu.route_management_service.domain.model.Stop;
+import com.gtu.route_management_service.infrastructure.persistence.mappers.StopMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class StopRepositoryImplTest {
+
+    @Mock
+    private JpaStopRepository jpaRepo;
+
+    @InjectMocks
+    private StopRepositoryImpl repository;
+
+    private final Stop stop = new Stop(1L, "Parada 1", null, null, null, null);
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void save_ShouldReturnSavedStop() {
+        when(jpaRepo.save(any())).thenReturn(StopMapper.toEntity(stop));
+
+        Stop result = repository.save(stop);
+
+        assertEquals(stop.getId(), result.getId());
+    }
+
+    @Test
+    void findById_ShouldReturnStop() {
+        when(jpaRepo.findById(1L)).thenReturn(Optional.of(StopMapper.toEntity(stop)));
+
+        Optional<Stop> result = repository.findById(1L);
+
+        assertTrue(result.isPresent());
+        assertEquals(1L, result.get().getId());
+    }
+
+    @Test
+    void findAll_ShouldReturnListOfStops() {
+        when(jpaRepo.findAll()).thenReturn(List.of(StopMapper.toEntity(stop)));
+
+        List<Stop> result = repository.findAll();
+
+        assertFalse(result.isEmpty());
+    }
+
+    @Test
+    void deleteById_ShouldCallDelete() {
+        doNothing().when(jpaRepo).deleteById(1L);
+
+        repository.deleteById(1L);
+
+        verify(jpaRepo, times(1)).deleteById(1L);
+    }
+
+    @Test
+    void existsById_ShouldReturnTrue() {
+        when(jpaRepo.existsById(1L)).thenReturn(true);
+
+        assertTrue(repository.existsById(1L));
+    }
+}

--- a/src/test/java/com/gtu/route_management_service/infrastructure/persistence/mappers/NeighborhoodMapperTest.java
+++ b/src/test/java/com/gtu/route_management_service/infrastructure/persistence/mappers/NeighborhoodMapperTest.java
@@ -1,0 +1,80 @@
+package com.gtu.route_management_service.infrastructure.persistence.mappers;
+
+import com.gtu.route_management_service.domain.model.Neighborhood;
+import com.gtu.route_management_service.infrastructure.persistence.entities.NeighborhoodEntity;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NeighborhoodMapperTest {
+
+    @Test
+    void toDomain_ShouldMapCorrectly() {
+        NeighborhoodEntity entity = new NeighborhoodEntity(1L, "Centro");
+        Neighborhood result = NeighborhoodMapper.toDomain(entity);
+
+        assertNotNull(result);
+        assertEquals(1L, result.getId());
+        assertEquals("Centro", result.getName());
+    }
+
+    @Test
+    void toDomain_ShouldReturnNull_WhenInputNull() {
+        assertNull(NeighborhoodMapper.toDomain(null));
+    }
+
+    @Test
+    void toEntity_ShouldMapCorrectly() {
+        Neighborhood domain = new Neighborhood(2L, "Sur");
+        NeighborhoodEntity result = NeighborhoodMapper.toEntity(domain);
+
+        assertNotNull(result);
+        assertEquals(2L, result.getId());
+        assertEquals("Sur", result.getName());
+    }
+
+    @Test
+    void toEntity_ShouldReturnNull_WhenInputNull() {
+        assertNull(NeighborhoodMapper.toEntity(null));
+    }
+
+    @Test
+    void toDomainList_ShouldMapListCorrectly() {
+        List<NeighborhoodEntity> entities = List.of(
+                new NeighborhoodEntity(1L, "Centro"),
+                new NeighborhoodEntity(2L, "Norte")
+        );
+
+        List<Neighborhood> result = NeighborhoodMapper.toDomainList(entities);
+
+        assertEquals(2, result.size());
+        assertEquals("Centro", result.get(0).getName());
+    }
+
+    @Test
+    void toEntityList_ShouldMapListCorrectly() {
+        List<Neighborhood> domains = List.of(
+                new Neighborhood(1L, "Sur"),
+                new Neighborhood(2L, "Este")
+        );
+
+        List<NeighborhoodEntity> result = NeighborhoodMapper.toEntityList(domains);
+
+        assertEquals(2, result.size());
+        assertEquals("Este", result.get(1).getName());
+    }
+
+    @Test
+    void toDomainList_ShouldReturnEmptyList_WhenNullInput() {
+        List<Neighborhood> result = NeighborhoodMapper.toDomainList(null);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void toEntityList_ShouldReturnEmptyList_WhenNullInput() {
+        List<NeighborhoodEntity> result = NeighborhoodMapper.toEntityList(null);
+        assertTrue(result.isEmpty());
+    }
+}

--- a/src/test/java/com/gtu/route_management_service/infrastructure/persistence/mappers/RouteEntityMapperTest.java
+++ b/src/test/java/com/gtu/route_management_service/infrastructure/persistence/mappers/RouteEntityMapperTest.java
@@ -1,0 +1,53 @@
+package com.gtu.route_management_service.infrastructure.persistence.mappers;
+
+import com.gtu.route_management_service.domain.model.Route;
+import com.gtu.route_management_service.infrastructure.persistence.entities.NeighborhoodEntity;
+import com.gtu.route_management_service.infrastructure.persistence.entities.RouteEntity;
+import com.gtu.route_management_service.infrastructure.persistence.entities.StopEntity;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RouteEntityMapperTest {
+
+    @Test
+    void toEntity_ShouldMapCorrectly() {
+        Route route = new Route(1L, "Ruta A", "Desc", LocalTime.of(8, 0), LocalTime.of(10, 0), List.of(1L), List.of(2L));
+
+        NeighborhoodEntity neighborhood = new NeighborhoodEntity(1L);
+        StopEntity stop = new StopEntity(2L);
+
+        RouteEntity entity = RouteEntityMapper.toEntity(route, List.of(neighborhood), List.of(stop));
+
+        assertNotNull(entity);
+        assertEquals("Ruta A", entity.getName());
+        assertEquals(1, entity.getNeighborhood().size());
+        assertEquals(2L, entity.getStop().get(0).getId());
+    }
+
+    @Test
+    void toDomain_ShouldMapCorrectly() {
+        NeighborhoodEntity neighborhood = new NeighborhoodEntity(1L, "Centro");
+        StopEntity stop = new StopEntity(2L, "Parada", "Desc", 1L, 10.0, 20.0);
+
+        RouteEntity entity = new RouteEntity(
+                1L,
+                "Ruta B",
+                "Descripcion",
+                LocalTime.of(9, 0),
+                LocalTime.of(11, 0),
+                List.of(neighborhood),
+                List.of(stop)
+        );
+
+        Route result = RouteEntityMapper.toDomain(entity);
+
+        assertNotNull(result);
+        assertEquals("Ruta B", result.getName());
+        assertEquals(1, result.getNeighborhoodIds().size());
+        assertEquals(2L, result.getStopsIds().get(0));
+    }
+}

--- a/src/test/java/com/gtu/route_management_service/infrastructure/persistence/mappers/StopMapperTest.java
+++ b/src/test/java/com/gtu/route_management_service/infrastructure/persistence/mappers/StopMapperTest.java
@@ -1,0 +1,78 @@
+package com.gtu.route_management_service.infrastructure.persistence.mappers;
+
+import com.gtu.route_management_service.domain.model.Stop;
+import com.gtu.route_management_service.infrastructure.persistence.entities.StopEntity;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StopMapperTest {
+
+    @Test
+    void toDomain_ShouldMapCorrectly() {
+        StopEntity entity = new StopEntity(1L, "Parada A", "Descripción", 10L, 12.34, 56.78);
+        Stop result = StopMapper.toDomain(entity);
+
+        assertNotNull(result);
+        assertEquals(1L, result.getId());
+        assertEquals("Parada A", result.getName());
+    }
+
+    @Test
+    void toDomain_ShouldReturnNull_WhenInputNull() {
+        assertNull(StopMapper.toDomain(null));
+    }
+
+    @Test
+    void toEntity_ShouldMapCorrectly() {
+        Stop domain = new Stop(2L, "Parada B", "Otra descripción", 11L, 98.76, 54.32);
+        StopEntity result = StopMapper.toEntity(domain);
+
+        assertNotNull(result);
+        assertEquals(2L, result.getId());
+        assertEquals(11L, result.getNeighborhoodId());
+    }
+
+    @Test
+    void toEntity_ShouldReturnNull_WhenInputNull() {
+        assertNull(StopMapper.toEntity(null));
+    }
+
+    @Test
+    void toDomainList_ShouldMapListCorrectly() {
+        List<StopEntity> entities = List.of(
+                new StopEntity(1L, "A", "Desc A", 5L, 10.0, 20.0),
+                new StopEntity(2L, "B", "Desc B", 6L, 30.0, 40.0)
+        );
+
+        List<Stop> result = StopMapper.toDomainList(entities);
+
+        assertEquals(2, result.size());
+        assertEquals("A", result.get(0).getName());
+    }
+
+    @Test
+    void toEntityList_ShouldMapListCorrectly() {
+        List<Stop> domains = List.of(
+                new Stop(1L, "X", "Desc X", 1L, 10.0, 20.0),
+                new Stop(2L, "Y", "Desc Y", 2L, 30.0, 40.0)
+        );
+
+        List<StopEntity> result = StopMapper.toEntityList(domains);
+
+        assertEquals(2, result.size());
+        assertEquals("Y", result.get(1).getName());
+    }
+
+    @Test
+    void toDomainList_ShouldReturnEmpty_WhenNull() {
+        assertTrue(StopMapper.toDomainList(null).isEmpty());
+    }
+
+    @Test
+    void toEntityList_ShouldReturnEmpty_WhenNull() {
+        assertTrue(StopMapper.toEntityList(null).isEmpty());
+    }
+}


### PR DESCRIPTION
This pull request adds comprehensive unit tests for repository implementations and their associated mappers in the `route_management_service` module. The changes ensure that key functionalities of saving, retrieving, and mapping domain objects are thoroughly validated.

### Repository Tests:
* Added unit tests for `NeighborhoodRepositoryImpl` to validate CRUD operations and existence checks.
* Added unit tests for `RouteRepositoryImpl` to validate CRUD operations, retrieval by name, and existence checks.
* Added unit tests for `StopRepositoryImpl` to validate CRUD operations and existence checks.

### Mapper Tests:
* Added unit tests for `NeighborhoodMapper` to validate domain-to-entity and entity-to-domain conversions, including handling null and list inputs.
* Added unit tests for `RouteEntityMapper` to validate domain-to-entity and entity-to-domain conversions, including mapping associated neighborhoods and stops.
* Added unit tests for `StopMapper` to validate domain-to-entity and entity-to-domain conversions, including handling null and list inputs.…pers