### PR TITLE
Remove @CrossOrigin annotation from Neighborhood, Route, and Stop con…

### DIFF
--- a/src/main/java/com/gtu/route_management_service/presentation/rest/NeighborhoodController.java
+++ b/src/main/java/com/gtu/route_management_service/presentation/rest/NeighborhoodController.java
@@ -15,7 +15,6 @@ import java.util.List;
 @RestController
 @RequestMapping("/neighborhoods")
 @Tag(name = "Neighborhoods", description = "Endpoints for managing neighborhoods")
-@CrossOrigin(origins = "*")
 public class NeighborhoodController {
 
     private final NeighborhoodUseCase neighborhoodUseCase;

--- a/src/main/java/com/gtu/route_management_service/presentation/rest/RouteController.java
+++ b/src/main/java/com/gtu/route_management_service/presentation/rest/RouteController.java
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/routes")
 @Tag    (name = "Routes", description = "Endpoints for managing routes")
-@CrossOrigin(origins = "*")
 public class RouteController {
     private final RouteUseCase routeUseCase;
 

--- a/src/main/java/com/gtu/route_management_service/presentation/rest/StopController.java
+++ b/src/main/java/com/gtu/route_management_service/presentation/rest/StopController.java
@@ -15,7 +15,6 @@ import java.util.List;
 @RestController
 @RequestMapping("/stops")
 @Tag(name = "Stops", description = "Endpoints for managing stops")
-@CrossOrigin(origins = "*")
 public class StopController {
     private final StopUseCase stopUseCase;
 


### PR DESCRIPTION
This pull request removes the `@CrossOrigin` annotation from several controller classes in the `route_management_service` project. This change simplifies the code by eliminating redundant configuration, assuming that cross-origin resource sharing (CORS) is handled globally or elsewhere in the application.

### Removal of `@CrossOrigin` annotations:

* [`src/main/java/com/gtu/route_management_service/presentation/rest/NeighborhoodController.java`](diffhunk://#diff-bab095548e0a13dae82756c926c450412f2ea7cee23c5f564f6686c920be6985L18): Removed `@CrossOrigin(origins = "*")` annotation from the `NeighborhoodController` class.
* [`src/main/java/com/gtu/route_management_service/presentation/rest/RouteController.java`](diffhunk://#diff-0f14dd49505b77c2a4faa5a995073163cef2d16d10cc02638df05e8ada8dda71L20): Removed `@CrossOrigin(origins = "*")` annotation from the `RouteController` class.
* [`src/main/java/com/gtu/route_management_service/presentation/rest/StopController.java`](diffhunk://#diff-4056e9de1a4e349d739fd56769977cb12b44d196469725383f2291b346c352deL18): Removed `@CrossOrigin(origins = "*")` annotation from the `StopController` class.…trollers